### PR TITLE
Update Tariff.php

### DIFF
--- a/src/BaseTypes/Tariff.php
+++ b/src/BaseTypes/Tariff.php
@@ -20,6 +20,13 @@ class Tariff extends Tarifflist
     public $tariff_code;
 
     /**
+     * Дополнительные услуги
+     * @Type("array<CdekSDK2\BaseTypes\Services>")
+     * @var Services[]
+     */
+    public $services;
+
+    /**
      * Intake constructor.
      * @param array $param
      */
@@ -28,5 +35,13 @@ class Tariff extends Tarifflist
         parent::__construct($param);
 
         $this->rules['tariff_code'] = 'numeric|required';
+        $this->rules['services'] = [
+            '',
+            function ($value) {
+                if ($value instanceof Services) {
+                    return $value->validate();
+                }
+            }
+        ];
     }
 }


### PR DESCRIPTION
При расчете стоимости доставки через api есть возможность передать параметры доп услуг services, но в случае с последней версией SDK в базовом классе https://github.com/cdek-it/sdk2.0/blob/master/src/BaseTypes/Tariff.php отсутствует возможность передать параметры доп услуг через базовый тип https://github.com/cdek-it/sdk2.0/blob/master/src/BaseTypes/Services.php хотелось бы иметь такую возможность.

Сейчас параметры услуг можно передать только через массив и придется реализовать отдельный клиент для этого, т.к. метод add() отправит запрос на роут "/tarifflist" если передать просто массив, см. https://github.com/cdek-it/sdk2.0/blob/master/src/Actions/Calculator.php#L44 т.е. через sdk2.0 невозможно рассчитать стоимость доставки с учетом доп услуг, хотя в API вроде бы такая возможность есть... https://apidoc.cdek.ru/#tag/calculator/operation/tariff

